### PR TITLE
Highlight Current Prayer Time in MMM-PrayerTime Module

### DIFF
--- a/MMM-PrayerTime.css
+++ b/MMM-PrayerTime.css
@@ -12,3 +12,10 @@
 .MMM-PrayerTime .occasion-time {
   text-align: center;
 }
+
+.MMM-PrayerTime .current-prayer {
+    color: #FFFF00; /* Bright yellow color */
+    font-weight: bold;
+    font-size: 110%;
+    text-shadow: 0 0 8px rgba(255, 255, 0, 0.5);
+}

--- a/MMM-PrayerTime.js
+++ b/MMM-PrayerTime.js
@@ -314,7 +314,7 @@ Module.register("MMM-PrayerTime",{
           occasionTimeNext.innerHTML = this.translate('TOMORROW');
           row.appendChild(occasionTimeNext);
         }
-
+	var now = moment();
         //for (var i = 0, count = this.todaySchedule.length; i < count; i++) {
         //for (t in this.todaySchedule)
         for (t in this.arrTodaySchedule)

--- a/MMM-PrayerTime.js
+++ b/MMM-PrayerTime.js
@@ -319,6 +319,18 @@ Module.register("MMM-PrayerTime",{
         //for (t in this.todaySchedule)
         for (t in this.arrTodaySchedule)
         {
+	  // Check if the current time is within the prayer time
+          var prayerStartTime = moment(this.arrTodaySchedule[t][1], "HH:mm");
+          var prayerEndTime = moment(this.arrTodaySchedule[(parseInt(t) + 1) % this.arrTodaySchedule.length][1], "HH:mm");
+
+          // If the prayer end time is before the start time, it means the prayer time spans midnight
+          if (prayerEndTime.isBefore(prayerStartTime)) {
+            prayerEndTime.add(1, 'day');
+          }
+          currentPrayerClass = "";
+          if (now.isBetween(prayerStartTime, prayerEndTime)) {
+            currentPrayerClass = "current-prayer";
+          }
           row = document.createElement("tr");
           if (this.config.colored) {
             row.className = "colored";
@@ -326,14 +338,15 @@ Module.register("MMM-PrayerTime",{
           table.appendChild(row);
 
           var occasionName = document.createElement("td");
-          occasionName.className = "occasion-name bright light";
+          occasionName.className = "occasion-name bright light " + currentPrayerClass;
+          
           //occasionName.innerHTML = this.translate(t);
           occasionName.innerHTML = this.translate(this.arrTodaySchedule[t][0].toUpperCase());
           row.appendChild(occasionName);
 
           // today
           var occasionTime = document.createElement("td");
-          occasionTime.className = "occasion-time bright light";
+          occasionTime.className = "occasion-time bright light " + currentPrayerClass;
           //occasionTime.innerHTML = this.todaySchedule[t];
           occasionTime.innerHTML = (this.config.timeFormat == 12 ? moment(this.arrTodaySchedule[t][1], ["HH:mm"]).format("h:mm A") : this.arrTodaySchedule[t][1]);
           row.appendChild(occasionTime);


### PR DESCRIPTION
# Highlight Current Prayer Time in MMM-PrayerTime Module

This PR adds visual highlighting to indicate the current prayer time in the MMM-PrayerTime module.

## Changes

### Visual Enhancements
- Added highlighting for the current prayer time with:
  - Yellow color
  - Bold text
  - 110% size increase
  - Subtle glow effect (text shadow)

### Technical Implementation
- Added CSS classes for styling current prayer time
- Implemented logic to determine current prayer time by:
  - Calculating prayer time intervals
  - Handling prayer times that span across midnight
  - Applying highlight classes to both prayer name and time

### Files Changed
1. `MMM-PrayerTime.css`:
   - Added `.current-prayer` class with visual styling
2. `MMM-PrayerTime.js`:
   - Added time comparison logic
   - Applied CSS classes dynamically based on current time

## Screenshots
<img width="1319" alt="Screenshot 2025-03-16 at 9 54 11 PM" src="https://github.com/user-attachments/assets/0a9eac72-dcda-4292-bca5-4f8c2100de69" />

